### PR TITLE
Add variants for choosing which order to search parents and kids

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,3 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/PistonDevelopers/find_folder.git"
 homepage = "https://github.com/PistonDevelopers/find_folder"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "find_folder"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 keywords = ["search", "directory", "folder", "find", "dir"]
 description = "A simple tool for finding the absolute path to a folder with a given name."

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -7,6 +7,8 @@ fn main() {
     println!("{:?}", Search::Parents(3).for_folder("src"));
     println!("{:?}", Search::Kids(3).for_folder("examples"));
     println!("{:?}", Search::Both(3, 3).for_folder("target"));
+    println!("{:?}", Search::ParentsThenKids(3, 3).for_folder("src"));
+    println!("{:?}", Search::KidsThenParents(3, 3).for_folder("examples"));
 }
 
 


### PR DESCRIPTION
Also expose the `check_dir`, `check_parents` and `check_kids` directory in case user desires more control.
