### PR TITLE
Fix code example in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ use find_folder::Search;
 fn main() {
     println!("{:?}", Search::Parents(3).for_folder("src"));
     println!("{:?}", Search::Kids(3).for_folder("examples"));
-    println!("{:?}", Search::Both(3, 3).for_folder("target"));
+    println!("{:?}", Search::ParentsThenKids(3, 3).for_folder("target"));
+    println!("{:?}", Search::KidsThenParents(3, 3).for_folder("target"));
 }
 ```
 


### PR DESCRIPTION
Since 879e162174e892e1c971d0f5d9aa75131f283168 the `Both` variant of
`Search` was removed. This updates the `README.md`, such that this
change is reflected, to ensure that the provided example will compile.